### PR TITLE
Remove Japanese signs which shouldn't be contained in hash

### DIFF
--- a/markdown_relative_link_checker.rb
+++ b/markdown_relative_link_checker.rb
@@ -39,6 +39,7 @@ class MarkdownFile
 
   def line_to_section_url(l)
     section_name = l.sub(/^#+ /, '').downcase.gsub(' ', '-').gsub(/[!-,:-@\[-\^{-~.\/`]/, '')
+    section_name = section_name.gsub('、', '').gsub('「', '').gsub('」', '')
     @path + '#' + CGI.escape(section_name)
   end
 


### PR DESCRIPTION
As far as I tested, GitHub removes `、`, `「` and `」` when it create a link to a section.
Therefore, markdown_relative_link_checker consider a correct link as a dead link if it has the above signs.

Maybe, there are more signs which markdown_relative_link_checker should remove, but this pull request removes signs which I already found.